### PR TITLE
Allow setting chai options

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,16 @@ module.exports = function(config) {
   config.set({
 
     // frameworks to use
-    frameworks: ['mocha', 'chai-sinon']
+    frameworks: ['mocha', 'chai-sinon'],
+    
+    // optionally set chai options
+    chaiSinon: {
+      chaiOptions: {
+        includeStack: true,
+        showDiff: false,
+        truncateThreshold: 0
+      }
+    }
 
     // ...
 ```

--- a/adapter.js
+++ b/adapter.js
@@ -1,4 +1,12 @@
 (function(window) {
+  var pluginConfig = window.__karma__.config.chaiSinon;
+
+  if (pluginConfig && pluginConfig.chaiOptions) {
+    Object.keys(pluginConfig.chaiOptions).forEach(function (key) {
+      window.chai.config[key] = pluginConfig.chaiOptions[key];
+    });
+  }
+
   window.should = null; // Workaround for "RangeError: Maximum call stack size exceeded." in PhantomJS
   window.should = window.chai.should();
   window.expect = window.chai.expect;

--- a/index.js
+++ b/index.js
@@ -4,12 +4,14 @@ var createPattern = function(path) {
   return {pattern: path, included: true, served: true, watched: false};
 };
 
-var framework = function(files) {
-  files.unshift(createPattern(__dirname + '/adapter.js'));
-  files.unshift(createPattern(path.dirname(require.resolve('sinon-chai')) + '/sinon-chai.js'));
-  files.unshift(createPattern(path.dirname(require.resolve('chai')) + '/chai.js'));
-  files.unshift(createPattern(path.dirname(require.resolve('sinon')) + '/../pkg/sinon.js'));
+var framework = function(config) {
+  if (config.chaiSinon) {
+    config.client.chaiSinon = config.chaiSinon;
+  }
+  config.files.unshift(createPattern(__dirname + '/adapter.js'));
+  config.files.unshift(createPattern(path.dirname(require.resolve('sinon-chai')) + '/sinon-chai.js'));
+  config.files.unshift(createPattern(path.dirname(require.resolve('chai')) + '/chai.js'));
+  config.files.unshift(createPattern(path.dirname(require.resolve('sinon')) + '/../pkg/sinon.js'));
 };
 
-framework.$inject = ['config.files'];
 module.exports = {'framework:chai-sinon': ['factory', framework]};


### PR DESCRIPTION
This allows Chai options to be set in the Karma config. e.g.,

```
config.set({
  chaiSinon: {
    chaiOptions: {
      includeStack: true,
      showDiff: false,
      truncateThreshold: 0
    }
  }
});
```
