### PR TITLE
fix: Remove chai and adapter to allow using karma-chai

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 karma-chai-sinon
 ==========
 
-[Chai](http://chaijs.com) + [Sinon-Chai](http://chaijs.com/plugins/sinon-chai) + [Sinon](http://sinonjs.org/) for [Karma](http://karma-runner.github.io)
+[Sinon-Chai](http://chaijs.com/plugins/sinon-chai) + [Sinon](http://sinonjs.org/) for [Karma](http://karma-runner.github.io)
 
 *What makes this plugin different from `karma-sinon-chai`?*
-* It allows you to use either the latest versions of sinon, chai and sinon-chai or the specific versions your project already uses.
+* It allows you to use either the latest versions of sinon and sinon-chai or the specific versions your project already uses.
 * It uses `peerDependencies` only.
 * No `bower` dependency.
 
@@ -16,14 +16,10 @@ Installation
 Install the plugin from npm:
 
 ```sh
-$ npm install karma-chai-sinon --save-dev
+$ npm install karma-chai-sinon karma-chai --save-dev
 ```
 
-Install the plugin from Github:
-
-```sh
-$ npm install 'git://github.com/tubalmartin/karma-chai-sinon.git' --save-dev
-```
+Note that karma-chai is a peer dependency, so it must be installed separately.
 
 Add `chai-sinon` to the `frameworks` key in your Karma configuration:
 
@@ -32,10 +28,12 @@ module.exports = function(config) {
   config.set({
 
     // frameworks to use
-    frameworks: ['mocha', 'chai-sinon']
+    frameworks: ['mocha', 'chai-sinon', 'chai']
 
     // ...
 ```
+
+It should be before `chai`, as Karma loads modules in reverse.
 
 License
 -------

--- a/adapter.js
+++ b/adapter.js
@@ -1,6 +1,0 @@
-(function(window) {
-  window.should = null; // Workaround for "RangeError: Maximum call stack size exceeded." in PhantomJS
-  window.should = window.chai.should();
-  window.expect = window.chai.expect;
-  window.assert = window.chai.assert;
-})(window);

--- a/index.js
+++ b/index.js
@@ -5,9 +5,7 @@ var createPattern = function(path) {
 };
 
 var framework = function(files) {
-  files.unshift(createPattern(__dirname + '/adapter.js'));
   files.unshift(createPattern(path.dirname(require.resolve('sinon-chai')) + '/sinon-chai.js'));
-  files.unshift(createPattern(path.dirname(require.resolve('chai')) + '/chai.js'));
   files.unshift(createPattern(path.dirname(require.resolve('sinon')) + '/../pkg/sinon.js'));
 };
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   },
   "peerDependencies": {
     "karma": ">=0.6",
-    "chai": "*",
+    "karma-chai": "*",
     "sinon-chai": "*",
     "sinon": "*"
   },


### PR DESCRIPTION
This plugin overlaps with what karma-chai does. To satisfy peer dependencies on karma-chai-as-promised, I believe this approach is better.

Note that it is a breaking change.

Fixes https://github.com/tubalmartin/karma-chai-sinon/issues/9
